### PR TITLE
fix a typo for ble connected check

### DIFF
--- a/kmk/hid.py
+++ b/kmk/hid.py
@@ -282,7 +282,7 @@ class BLEHID(AbstractHID):
     def ble_monitor(self):
         if self.ble_connected != self.connected:
             self.ble_connected = self.connected
-            if self._connected:
+            if self.connected:
                 if debug.enabled:
                     debug('BLE connected')
             else:


### PR DESCRIPTION
The hid.py code currently puts out a stacktrace that `_connected` does not exist. It looks like `_connected` was refactored to `connected` recently so I changed this bit here.